### PR TITLE
Potential fix for code scanning alert no. 5: Binding a socket to all network interfaces

### DIFF
--- a/src/gatenet/diagnostics/traceroute.py
+++ b/src/gatenet/diagnostics/traceroute.py
@@ -39,7 +39,7 @@ def traceroute(
         # Create a raw socket to receive ICMP responses
         recv_sock = socket.socket(socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_ICMP)
         recv_sock.settimeout(timeout)
-        recv_sock.bind(("", port))
+        recv_sock.bind(("127.0.0.1", port))
 
         # Send a UDP packet to the destination
         start_time = time.time()


### PR DESCRIPTION
Potential fix for [https://github.com/clxrityy/gatenet/security/code-scanning/5](https://github.com/clxrityy/gatenet/security/code-scanning/5)

To address the issue, the receiving socket (`recv_sock`) should be bound to a specific interface or IP address rather than all interfaces. This can be achieved by replacing the empty string (`""`) in the `bind` call with a specific IP address. If the application is intended to run on a machine with multiple interfaces, the IP address of the desired interface should be used. Alternatively, the loopback address (`127.0.0.1`) can be used if the socket is only intended for local communication.

The fix involves:
1. Identifying the appropriate IP address to bind the socket to.
2. Updating the `recv_sock.bind` call to use this IP address instead of `""`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
