### PR TITLE
Potential fix for code scanning alert no. 7: Binding a socket to all network interfaces

### DIFF
--- a/src/gatenet/diagnostics/traceroute.py
+++ b/src/gatenet/diagnostics/traceroute.py
@@ -2,7 +2,7 @@ import socket
 import time
 from typing import List, Tuple, Optional
 
-def _create_sockets(ttl: int, protocol: str, port: int, timeout: float):
+def _create_sockets(ttl: int, protocol: str, port: int, timeout: float, interface: str = "127.0.0.1"):
     if protocol == "udp":
         send_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         send_sock.setsockopt(socket.SOL_IP, socket.IP_TTL, ttl)
@@ -14,7 +14,7 @@ def _create_sockets(ttl: int, protocol: str, port: int, timeout: float):
     except PermissionError:
         raise PermissionError("Raw sockets require admin/root privileges.")
     recv_sock.settimeout(timeout)
-    recv_sock.bind(("0.0.0.0", port))
+    recv_sock.bind((interface, port))
     return send_sock, recv_sock
 
 def _send_probe(send_sock, dest_addr, protocol, port):
@@ -132,4 +132,6 @@ def traceroute(
         if curr_addr == dest_addr:
             break
 
+    interface = "127.0.0.1"  # Replace with the desired interface IP address
+    send_sock, recv_sock = _create_sockets(ttl, protocol, port, timeout, interface)
     return result


### PR DESCRIPTION
Potential fix for [https://github.com/clxrityy/gatenet/security/code-scanning/7](https://github.com/clxrityy/gatenet/security/code-scanning/7)

To fix the issue, the socket should be bound to a specific network interface instead of `0.0.0.0`. This can be achieved by replacing `recv_sock.bind(("0.0.0.0", port))` with a binding to a dedicated interface. The interface IP address can be passed as an argument to the `_create_sockets` function, allowing the user to specify the desired interface. If no specific interface is provided, the function can default to a secure option, such as localhost (`127.0.0.1`).

Changes required:
1. Add an `interface` parameter to `_create_sockets` to specify the IP address of the interface to bind.
2. Replace `recv_sock.bind(("0.0.0.0", port))` with `recv_sock.bind((interface, port))`.
3. Update calls to `_create_sockets` to pass the appropriate interface.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
