### PR TITLE
Potential fix for code scanning alert no. 14: Information exposure through an exception

### DIFF
--- a/src/gatenet/dashboard/app.py
+++ b/src/gatenet/dashboard/app.py
@@ -16,6 +16,7 @@ import time
 from fastapi import Query
 from fastapi.middleware.cors import CORSMiddleware
 
+import logging
 app = FastAPI(title="Gatenet Dashboard", docs_url="/docs")
 
 # Allow CORS for local development
@@ -162,7 +163,8 @@ def api_traceroute(host: str = Query(..., description="Host to traceroute")):
         hops = traceroute(host)
         return {"ok": True, "hops": hops}
     except Exception as e:
-        return {"ok": False, "error": str(e)}
+        logging.exception("Error in /api/traceroute endpoint")
+        return {"ok": False, "error": "An internal error has occurred."}
 
 def launch_dashboard(host: str = "127.0.0.1", port: int = 8000, open_browser: bool = True) -> None:
     """


### PR DESCRIPTION
Potential fix for [https://github.com/clxrityy/gatenet/security/code-scanning/14](https://github.com/clxrityy/gatenet/security/code-scanning/14)

To fix the problem, we should avoid returning the raw exception message to the client. Instead, we should log the exception details (including stack trace) on the server for debugging purposes, and return a generic error message to the client. This change should be made in the exception handler of the `/api/traceroute` endpoint (lines 164-165). We need to import the `logging` module (or use FastAPI's logger) and log the exception in the `except` block. The client should receive a generic message such as `"An internal error has occurred."` instead of the exception details.

**Required changes:**
- Import the `logging` module.
- Log the exception in the `except` block of `api_traceroute`.
- Return a generic error message to the client.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
