### PR TITLE
Potential fix for code scanning alert no. 25: Information exposure through an exception

### DIFF
--- a/src/gatenet/diagnostics/ping.py
+++ b/src/gatenet/diagnostics/ping.py
@@ -7,6 +7,8 @@ from typing import Dict, Union
 import ipaddress
 import re
 import statistics
+GENERIC_ERROR_MESSAGE = "An internal error occurred."
+
 def _is_valid_host(host: str) -> bool:
     """Validate that host is a valid IPv4/IPv6 address or DNS hostname, and does not contain shell-special characters."""
     import socket
@@ -172,7 +174,7 @@ def _icmp_ping_sync(host: str, count: int, timeout: int, system: str) -> Dict[st
         return {
             "host": host,
             "success": False,
-            "error": str(e),
+            "error": GENERIC_ERROR_MESSAGE,
             "raw_output": ""
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/clxrityy/gatenet/security/code-scanning/25](https://github.com/clxrityy/gatenet/security/code-scanning/25)

The best way to fix this problem is to sanitize the `"error"` field in the return dictionary of the ping and lower-level functions. Instead of returning `str(e)` (the exception text, potentially including stack information, file names, etc.), use a generic error message—such as the default `"An internal error occurred."` string already defined in the dashboard. This should be done everywhere `str(e)` is used as an error output sent back to a caller that might eventually send it to an external client.  
Specifically:

- In `src/gatenet/diagnostics/ping.py`, change the exception handler in `_icmp_ping_sync` (and, for thoroughness, in all similar sync/async ping procedures if applicable) to return a dictionary with `"error": GENERIC_ERROR_MESSAGE` rather than `"error": str(e)"`.
- Define `GENERIC_ERROR_MESSAGE` in this module—or import it if defined elsewhere.
- Review usages in related functions to ensure consistency.
- No changes needed to the dashboard endpoint, as it already ignores `"error"`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
